### PR TITLE
Exclude filestyem package from updating

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -15,6 +15,11 @@
 
 FROM docker.io/centos:8
 
+# NOTE(pabelanger): Until centos 8.3 container images is published to
+# docker.io/centos:8 we need to exclude filesystem from updating. See
+# https://bugs.centos.org/view.php?id=17915
+RUN echo -n "exclude=filesystem" >> /etc/dnf/dnf.conf
+
 RUN dnf update -y \
   && dnf install -y python3-pip python3-wheel \
   && dnf clean all \


### PR DESCRIPTION
With the release of centos 8.3, we are hitting a podman failure in
trying to update the filesystem package. This is because of how rootless
containers work.  Sadly, there is nothing we can do, without running our
image build as root.

For now, exclude the package until newer centos 8.3 images are published
to dockerhub.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>