### PR TITLE
Pull centos:8 from quay.io

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -13,12 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/centos:8
-
-# NOTE(pabelanger): Until centos 8.3 container images is published to
-# docker.io/centos:8 we need to exclude filesystem from updating. See
-# https://bugs.centos.org/view.php?id=17915
-RUN echo -n "exclude=filesystem" >> /etc/dnf/dnf.conf
+FROM quay.io/centos/centos:8
 
 RUN dnf update -y \
   && dnf install -y python3-pip python3-wheel \


### PR DESCRIPTION
This is now the official place to pull centos images from. We can also
remove our exclude hack, as latest images have fixed the issue.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>