### PR TITLE
Add periodic job to rebuild image

### DIFF
--- a/.zuul.d/project.yaml
+++ b/.zuul.d/project.yaml
@@ -13,3 +13,8 @@
         - python-builder-upload-container-image:
             vars:
               upload_container_image_promote: false
+    periodic:
+      jobs:
+        - python-builder-upload-container-image:
+            vars:
+              upload_container_image_promote: false


### PR DESCRIPTION
Start with rebuilding our image every 24 hours, this will help to avoid
stale images.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>