### PR TITLE
Drop other-requirements.txt support

### DIFF
--- a/scripts/assemble
+++ b/scripts/assemble
@@ -31,7 +31,7 @@ function install_bindep {
     # Protect from the bindep builder image use of the assemble script
     # to produce a wheel.  Note we append because we want all
     # sibling packages in here too
-    if [ -f bindep.txt -o -f other-requirements.txt ] ; then
+    if [ -f bindep.txt ] ; then
         bindep -l newline >> /output/bindep/run.txt || true
         compile_packages=$(bindep -b compile || true)
         if [ ! -z "$compile_packages" ] ; then


### PR DESCRIPTION
This was a legacy config file for bindep long ago, we can drop it here
as new projects have no idea about it.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>