### PR TITLE
Add support for EPEL packages

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -16,6 +16,8 @@
 FROM quay.io/centos/centos:8
 
 RUN dnf update -y \
+  && dnf install -y epel-release dnf-plugins-core \
+  && dnf config-manager --set-disabled epel \
   && dnf install -y python3-pip python3-wheel \
   && dnf clean all \
   && rm -rf /var/cache/dnf

--- a/scripts/assemble
+++ b/scripts/assemble
@@ -32,7 +32,10 @@ function install_bindep {
     # to produce a wheel.  Note we append because we want all
     # sibling packages in here too
     if [ -f bindep.txt ] ; then
-        bindep -l newline >> /output/bindep/run.txt || true
+        bindep -l newline | sort >> /output/bindep/run.txt || true
+        bindep -l newline -b epel | sort >> /output/bindep/stage.txt || true
+        grep -Fxvf /output/bindep/run.txt /output/bindep/stage.txt >> /output/bindep/epel.txt || true
+        rm -rf /output/bindep/stage.txt
         compile_packages=$(bindep -b compile || true)
         if [ ! -z "$compile_packages" ] ; then
             dnf install -y ${compile_packages}

--- a/scripts/install-from-bindep
+++ b/scripts/install-from-bindep
@@ -22,6 +22,11 @@ if [ ! -z "$PACKAGES" ]; then
     dnf install -y $PACKAGES
 fi
 
+EPEL_PACKAGES=$(cat /output/bindep/epel.txt)
+if [ ! -z "$EPEL_PACKAGES" ]; then
+    dnf install -y --enablerepo epel $EPEL_PACKAGES
+fi
+
 # If there's a constraints file, use it.
 if [ -f /output/upper-constraints.txt ] ; then
     CONSTRAINTS="-c /output/upper-constraints.txt"


### PR DESCRIPTION
We want the ability for bindep to support EPEL by default. This will
allow users to use the epel profile in bindep.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>