### PR TITLE
Use --no-cache-dir when upgrading pip

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -24,7 +24,7 @@ RUN dnf update -y \
 
 # Upgrade pip to fix wheel cache for locally built wheels.
 # See https://github.com/pypa/pip/issues/6852
-RUN pip3 install -U pip
+RUN pip3 install --no-cache-dir -U pip
 
 RUN pip3 install --no-cache-dir bindep
 


### PR DESCRIPTION
This will save us some space

Signed-off-by: Paul Belanger <pabelanger@redhat.com>