### PR TITLE
Use ansible/python-base:latest for our base image

### DIFF
--- a/.zuul.d/jobs.yaml
+++ b/.zuul.d/jobs.yaml
@@ -4,6 +4,7 @@
     parent: ansible-build-container-image
     description: Build python-builder container image
     provides: python-builder-container-image
+    requires: python-base-container-image
     vars: &vars
       container_images: &container_images
         - context: .
@@ -37,4 +38,5 @@
     description: Build python-builder container image and upload to quay.io
     timeout: 2700
     provides: python-builder-container-image
+    requires: python-base-container-image
     vars: *vars

--- a/Containerfile
+++ b/Containerfile
@@ -13,18 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM quay.io/centos/centos:8
+FROM quay.io/ansible/python-base:latest
+# =============================================================================
 
 RUN dnf update -y \
-  && dnf install -y epel-release dnf-plugins-core \
-  && dnf config-manager --set-disabled epel \
-  && dnf install -y python3-pip python3-wheel \
+  && dnf install -y python3-wheel \
   && dnf clean all \
   && rm -rf /var/cache/dnf
-
-# Upgrade pip to fix wheel cache for locally built wheels.
-# See https://github.com/pypa/pip/issues/6852
-RUN pip3 install --no-cache-dir -U pip
 
 RUN pip3 install --no-cache-dir bindep
 


### PR DESCRIPTION
We actually can remove some duplicate syntax by using
ansible/python-base:latest as our base image. This should be fine, as we
always want to ensure both python-builder / python-base are the same
distro.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>