### PR TITLE
Create empty bindep files

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -17,7 +17,7 @@ FROM quay.io/ansible/python-base:latest
 # =============================================================================
 
 RUN dnf update -y \
-  && dnf install -y python3-wheel \
+  && dnf install -y python38-wheel \
   && dnf clean all \
   && rm -rf /var/cache/dnf
 


### PR DESCRIPTION
It is possible, that a project might not have bindep.txt files. As a
result, the files will be missing in the output folder. We can just
prime the files to ensure they always exists, regardless of any
contents.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>