### PR TITLE
Enable powertools repo by default

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -17,6 +17,7 @@ FROM quay.io/ansible/python-base:latest
 # =============================================================================
 
 RUN dnf update -y \
+  && dnf config-manager --set-enabled powertools \
   && dnf install -y python38-wheel \
   && dnf clean all \
   && rm -rf /var/cache/dnf


### PR DESCRIPTION
Given we use this image to build python packages, enable powertools by
default. This allows users to use libyaml-devel for example, without
creating a new entry point in bindep.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>