### PR TITLE
Use --system-site-packages for our venv

### DIFF
--- a/scripts/assemble
+++ b/scripts/assemble
@@ -70,6 +70,7 @@ function install_wheels {
     fi
     # If we didn't build wheels, we can skip trying to install it.
     if [ $(ls -1 /output/wheels/*whl 2>/dev/null | wc -l) -gt 0 ]; then
+        /tmp/venv/bin/pip uninstall -y /output/wheels/*.whl
         /tmp/venv/bin/pip install $CONSTRAINTS --cache-dir=/output/wheels /output/wheels/*whl
     fi
 
@@ -95,7 +96,10 @@ done
 
 # Use a clean virtualenv for install steps to prevent things from the
 # current environment making us not build a wheel.
-python3.8 -m venv /tmp/venv
+# NOTE(pabelanger): We allow users to install distro python packages of
+# libraries. This is important for projects that eventually want to produce
+# an RPM or offline install.
+python3.8 -m venv /tmp/venv --system-site-packages
 /tmp/venv/bin/pip install -U pip wheel
 
 # If there is an upper-constraints.txt file in the source tree,

--- a/scripts/install-from-bindep
+++ b/scripts/install-from-bindep
@@ -56,15 +56,17 @@ if [ -f /output/packages.txt ] ; then
   # image.
   pip3 install $CONSTRAINTS --cache-dir=/output/wheels -r /output/packages.txt $EXTRAS
 else
-  # Install the wheels.  Use --force here because sibling wheels might
+  # Install the wheels. Uninstall any existing version as siblings maybe
   # be built with the same version number as the latest release, but we
   # really want the speculatively built wheels installed over any
   # automatic dependencies.
   # NOTE(pabelanger): It is possible a project may not have a wheel, but does have requirements.txt
   if [ $(ls -1 /output/wheels/*whl 2>/dev/null | wc -l) -gt 0 ]; then
-      pip3 install $CONSTRAINTS --force --cache-dir=/output/wheels /output/wheels/*.whl $EXTRAS
+      pip3 uninstall -y /output/wheels/*.whl
+      pip3 install $CONSTRAINTS --cache-dir=/output/wheels /output/wheels/*.whl $EXTRAS
   elif [ ! -z "$EXTRAS" ] ; then
-      pip3 install $CONSTRAINTS --force --cache-dir=/output/wheels $EXTRAS
+      pip3 uninstall -y $EXTRAS
+      pip3 install $CONSTRAINTS --cache-dir=/output/wheels $EXTRAS
   fi
 fi
 


### PR DESCRIPTION
This is important, because we don't actually want to pip install over
any distro python package.  I mean, we can but this isn't friendly to
downstream packagers.

Depends-On: https://github.com/ansible/python-base-image/pull/9
Signed-off-by: Paul Belanger <pabelanger@redhat.com>