### PR TITLE
Revert "Enable powertools repo by default"

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -17,7 +17,6 @@ FROM quay.io/ansible/python-base:latest
 # =============================================================================
 
 RUN dnf update -y \
-  && dnf config-manager --set-enabled powertools \
   && dnf install -y python38-wheel \
   && dnf clean all \
   && rm -rf /var/cache/dnf


### PR DESCRIPTION
We actually want this enabled in python-base, it is possible they are
also runtime dependencies.

This reverts commit 31ff8ff0687b725f2a5f38dde435180ea6e20628.

Depends-On: https://github.com/ansible/python-base-image/pull/9
Signed-off-by: Paul Belanger <pabelanger@redhat.com>