### PR TITLE
Include git by default in python-builder

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -17,7 +17,7 @@ FROM quay.io/ansible/python-base:latest
 # =============================================================================
 
 RUN dnf update -y \
-  && dnf install -y python38-wheel \
+  && dnf install -y python38-wheel git \
   && dnf clean all \
   && rm -rf /var/cache/dnf
 

--- a/scripts/assemble
+++ b/scripts/assemble
@@ -117,10 +117,6 @@ if [[ $PACKAGES ]] ; then
       echo "$package" >> /output/packages.txt
     done
 else
-    # pbr needs git installed, else nothing will work. Do this in between
-    # bindep and wheel so that we don't miss git in target images.
-    dnf install -y git
-
     install_wheels
 fi
 


### PR DESCRIPTION
We can reduce the runtime install of git, for the assemble script, and
ship git by default.

This should cut down on the need to install it everytime we want to
build a python package.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>