### PR TITLE
Stop installing pip / wheel inside the virtualenv

### DIFF
--- a/scripts/assemble
+++ b/scripts/assemble
@@ -103,8 +103,7 @@ done
 # NOTE(pabelanger): We allow users to install distro python packages of
 # libraries. This is important for projects that eventually want to produce
 # an RPM or offline install.
-python3.8 -m venv /tmp/venv --system-site-packages
-/tmp/venv/bin/pip install -U pip wheel
+python3.8 -m venv /tmp/venv --system-site-packages --without-pip
 
 # If there is an upper-constraints.txt file in the source tree,
 # use it in the pip commands.


### PR DESCRIPTION
Given we take the steps to ensure pip / wheel is already installed
properly inside the containers, there really isn't a need to re-update
these.

It also means one last thing to deal with for downstream builds and
cachito.

Depends-On: https://github.com/ansible/python-builder-image/pull/30
Signed-off-by: Paul Belanger <pabelanger@redhat.com>