### PR TITLE
Remove hardcoded python3.8 in assemble script

### DIFF
--- a/scripts/assemble
+++ b/scripts/assemble
@@ -59,7 +59,7 @@ function install_wheels {
     # possible to tell what is the wheel for the project and
     # what is the wheel cache.
     if [ -f setup.py ] ; then
-        python3.8 setup.py sdist bdist_wheel -d /output/wheels
+        python3 setup.py sdist bdist_wheel -d /output/wheels
     fi
 
     # Install everything so that the wheel cache is populated with
@@ -103,7 +103,7 @@ done
 # NOTE(pabelanger): We allow users to install distro python packages of
 # libraries. This is important for projects that eventually want to produce
 # an RPM or offline install.
-python3.8 -m venv /tmp/venv --system-site-packages --without-pip
+python3 -m venv /tmp/venv --system-site-packages --without-pip
 source /tmp/venv/bin/activate
 
 # If there is an upper-constraints.txt file in the source tree,


### PR DESCRIPTION
We should use python3, over python3.8. This allows for the option for
containers to use python3.6, depending how python-base is configured.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>