### PR TITLE
Ensure /tmp/src exists

### DIFF
--- a/scripts/assemble
+++ b/scripts/assemble
@@ -41,8 +41,11 @@ if [ -z $PKGMGR ]; then
     fi
 fi
 
+# NOTE(pabelanger): Ensure all the direcotry we use exists regardless
+# of the user first creating them or not.
 mkdir -p /output/bindep
 mkdir -p /output/wheels
+mkdir -p /tmp/src
 
 cd /tmp/src
 


### PR DESCRIPTION
Ensure /tmp/src exists

Don't die if /tmp/src doesn't exist, while we won't actually install
bindep or python packages, we will handle distro level updates properly.

This will fix:

  /usr/local/bin/assemble: line 47: cd: /tmp/src: No such file or directory

Signed-off-by: Paul Belanger <pabelanger@redhat.com>