### PR TITLE
scripts: fix PKGMGR_OPTS string test

### DIFF
--- a/scripts/assemble
+++ b/scripts/assemble
@@ -32,7 +32,7 @@ if [ -z $PKGMGR ]; then
     PKGMGR=/usr/bin/dnf
     if [ -f "/usr/bin/microdnf" ]; then
         PKGMGR=/usr/bin/microdnf
-        if [ -z $PKGMGR_OPTS ]; then
+        if [ -z "${PKGMGR_OPTS}" ]; then
             # NOTE(pabelanger): skip install docs and weak dependencies to
             # make smaller images. Sadly, setting these in dnf.conf don't
             # appear to work.

--- a/scripts/install-from-bindep
+++ b/scripts/install-from-bindep
@@ -25,7 +25,7 @@ if [ -z $PKGMGR ]; then
     PKGMGR=/usr/bin/dnf
     if [ -f "/usr/bin/microdnf" ]; then
         PKGMGR=/usr/bin/microdnf
-        if [ -z $PKGMGR_OPTS ]; then
+        if [ -z "${PKGMGR_OPTS}" ]; then
             # NOTE(pabelanger): skip install docs and weak dependencies to
             # make smaller images. Sadly, setting these in dnf.conf don't
             # appear to work.


### PR DESCRIPTION
When trying to override the PKGMGR_OPTS variable then the empty string test fails because the variable isn't quoted.

```bash
+ '[' -z --nodocs --setopt install_weak_deps=0 ']'
/usr/local/bin/assemble: line 35: [: too many arguments

```
Closes: #48

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>