### PR TITLE
assemble: Allow using PKGMGR_OPTS on update

### DIFF
--- a/scripts/assemble
+++ b/scripts/assemble
@@ -49,7 +49,7 @@ mkdir -p /tmp/src
 
 cd /tmp/src
 
-$PKGMGR update -y
+$PKGMGR update -y $PKGMGR_OPTS
 
 function install_bindep {
     # Protect from the bindep builder image use of the assemble script


### PR DESCRIPTION
Without using the `PKGMGR_OPTS` variable during the package update then we can still install weak dependencies.
This also allows one to exclude packages during upgrade if needed.

Signed-off-by: Dimitri Savineau <dsavinea@redhat.com>