### PR TITLE
Add options for security, all or no patches during build

### DIFF
--- a/scripts/assemble
+++ b/scripts/assemble
@@ -26,7 +26,12 @@ RELEASE=$(source /etc/os-release; echo $ID)
 # manager.
 PKGMGR="${PKGMGR:-}"
 PKGMGR_OPTS="${PKGMGR_OPTS:-}"
+PKGMGR_UPDATE="${PKGMGR_UPDATE:-}"
 
+# Install dnf because we need it for security patches only when defined
+if [[ $PKGMGR_UPDATE == 'security' && -f "/usr/bin/microdnf" ]]; then
+    /usr/bin/microdnf install dnf -y $PKGMGR_OPTS
+fi
 if [ -z $PKGMGR ]; then
     # Expect dnf to be installed, however if we find microdnf default to it.
     PKGMGR=/usr/bin/dnf
@@ -50,12 +55,12 @@ mkdir -p /tmp/src
 cd /tmp/src
 
 # run all, security or none for package update
-if [[ $PKG_UPDATE == 'all' ]]; then
+if [ $PKGMGR_UPDATE == 'all' ]; then
 	$PKGMGR update -y $PKGMGR_OPTS
-elif [[ $PKG_UPDATE == 'security' ]]; then
+elif [ $PKGMGR_UPDATE == 'security' ]; then
 	$PKGMGR update -y $PKGMGR_OPTS --security
-elif [[ $PKG_UPDATE == 'none' ]]; then
-	echo "Skipping dnf update(s) as defined: ${PKG_UPDATE}"
+elif [ $PKGMGR_UPDATE == 'none' ]; then
+	echo "Skipping dnf update(s) as defined: ${PKGMGR_UPDATE}"
 fi
 
 function install_bindep {

--- a/scripts/assemble
+++ b/scripts/assemble
@@ -49,7 +49,14 @@ mkdir -p /tmp/src
 
 cd /tmp/src
 
-$PKGMGR update -y $PKGMGR_OPTS
+# run all, security or none for package update
+if [[ $PKG_UPDATE == 'all' ]]; then
+	$PKGMGR update -y $PKGMGR_OPTS
+elif [[ $PKG_UPDATE == 'security' ]]; then
+	$PKGMGR update -y $PKGMGR_OPTS --security
+elif [[ $PKG_UPDATE == 'none' ]]; then
+	echo "Skipping dnf update(s) as defined: ${PKG_UPDATE}"
+fi
 
 function install_bindep {
     # Protect from the bindep builder image use of the assemble script

--- a/scripts/install-from-bindep
+++ b/scripts/install-from-bindep
@@ -19,11 +19,17 @@ set -ex
 # manager.
 PKGMGR="${PKGMGR:-}"
 PKGMGR_OPTS="${PKGMGR_OPTS:-}"
+PKGMGR_UPDATE="${PKGMGR_UPDATE:-}"
 
+# Install dnf because we need it for security patches only when defined
+if [[ $PKGMGR_UPDATE == 'security' && -f "/usr/bin/microdnf" ]]; then
+    /usr/bin/microdnf install dnf -y $PKGMGR_OPTS
+fi
 if [ -z $PKGMGR ]; then
     # Expect dnf to be installed, however if we find microdnf default to it.
-    PKGMGR=/usr/bin/dnf
-    if [ -f "/usr/bin/microdnf" ]; then
+    if [[ $PKGMGR_UPDATE == 'security' && -f "/usr/bin/dnf" ]]; then
+        PKGMGR=/usr/bin/dnf
+    elif [[ $PKGMGR_UPDATE != 'security' && -f "/usr/bin/microdnf" ]]; then
         PKGMGR=/usr/bin/microdnf
         if [ -z "${PKGMGR_OPTS}" ]; then
             # NOTE(pabelanger): skip install docs and weak dependencies to
@@ -35,12 +41,12 @@ if [ -z $PKGMGR ]; then
 fi
 
 # run all, security or none for package update
-if [[ $PKG_UPDATE == 'all' ]]; then
+if [ $PKGMGR_UPDATE == 'all' ]; then
 	$PKGMGR update -y $PKGMGR_OPTS
-elif [[ $PKG_UPDATE == 'security' ]]; then
+elif [ $PKGMGR_UPDATE == 'security' ]; then
 	$PKGMGR update -y $PKGMGR_OPTS --security
-elif [[ $PKG_UPDATE == 'none' ]]; then
-	echo "Skipping dnf update(s) as defined: ${PKG_UPDATE}"
+elif [ $PKGMGR_UPDATE == 'none' ]; then
+	echo "Skipping dnf update(s) as defined: ${PKGMGR_UPDATE}"
 fi
 
 if [ -f /output/bindep/run.txt ] ; then

--- a/scripts/install-from-bindep
+++ b/scripts/install-from-bindep
@@ -34,7 +34,14 @@ if [ -z $PKGMGR ]; then
     fi
 fi
 
-$PKGMGR update -y $PKGMGR_OPTS
+# run all, security or none for package update
+if [[ $PKG_UPDATE == 'all' ]]; then
+	$PKGMGR update -y $PKGMGR_OPTS
+elif [[ $PKG_UPDATE == 'security' ]]; then
+	$PKGMGR update -y $PKGMGR_OPTS --security
+elif [[ $PKG_UPDATE == 'none' ]]; then
+	echo "Skipping dnf update(s) as defined: ${PKG_UPDATE}"
+fi
 
 if [ -f /output/bindep/run.txt ] ; then
     PACKAGES=$(cat /output/bindep/run.txt)


### PR DESCRIPTION
This will make running updates more flexible for folks who may or may not want to run all patches on the images/containers depending on the lifecycle management. 